### PR TITLE
Reduce temp image cleanup interval from 24h to 1h

### DIFF
--- a/app/api/cleanup/route.js
+++ b/app/api/cleanup/route.js
@@ -12,8 +12,8 @@ export async function GET(request) {
   }
 
   try {
-    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    const isoDate = yesterday.toISOString().split(".")[0];
+    const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000);
+    const isoDate = oneHourAgo.toISOString().split(".")[0];
 
     const searchUrl = `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/resources/search`;
     const expression = `folder:temp_conversions AND uploaded_at<${isoDate}`;


### PR DESCRIPTION
Changes the automated cleanup job to delete temporary images after 1 hour instead of 24 hours. This reduces storage usage and ensures temp files are cleaned up more frequently.

- Updated cleanup interval from 24 hours to 1 hour
- Modified date calculation in cleanup cron job